### PR TITLE
Add triplestore container backup example to config.example.yaml

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -25,7 +25,7 @@ source_directories:
     # - /data/useful-scripts/virtuoso-backup.sh `/usr/bin/docker ps --filter "label=com.docker.compose.project=app-something" --filter "label=com.docker.compose.service=triplestore" --format "{{.Names}}"`
     # - /data/useful-scripts/virtuoso-backup.sh <another_container>
 # after_backup:
-    # - find /data/app-http-logger/data/logs -type f -delete
+    # - find /data/app-something/data/db/backups -type f -delete
 
 on_error:
     - echo "Error while creating a backup."

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -22,7 +22,7 @@ source_directories:
     # - "/data/app-something/data/files/*-*-*T*:*:*.*/*"
 
 # before_backup:
-    # - /data/useful-scripts/virtuoso-backup.sh <container>
+    # - /data/useful-scripts/virtuoso-backup.sh `/usr/bin/docker ps --filter "label=com.docker.compose.project=app-something" --filter "label=com.docker.compose.service=triplestore" --format "{{.Names}}"`
     # - /data/useful-scripts/virtuoso-backup.sh <another_container>
 # after_backup:
     # - find /data/app-http-logger/data/logs -type f -delete

--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -1,11 +1,11 @@
 version: '3'
+
 services:
   borgmatic:
     # Each source_directory must be mounted here to be accessible to the container
     volumes:
-      - /data/backups:/data/backups:ro
-      - /data/app-something/data/db/backups:/data/app-something/data/db/backups:ro
-
+      - /data/app-something/data/db:/data/app-something/data/db:ro
+      - /data/app-something/data/db/backups:/data/app-something/data/db/backups
   borgmatic-exporter:
     environment:
       # The exporter needs the exact names of config file(s)

--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -4,6 +4,7 @@ services:
   borgmatic:
     # Each source_directory must be mounted here to be accessible to the container
     volumes:
+      - /data/useful-scripts:/data/useful-scripts:ro
       - /data/app-something/data/db:/data/app-something/data/db:ro
       - /data/app-something/data/db/backups:/data/app-something/data/db/backups
   borgmatic-exporter:


### PR DESCRIPTION
Add example to use a generic way to select the triplestore service from a docker-compose project.