### PR TITLE
Remove container_name from docker-compose.yml

### DIFF
--- a/docker-compose.restore.yml
+++ b/docker-compose.restore.yml
@@ -1,7 +1,6 @@
 version: '3'
 services:
   borgmatic:
-    container_name: borgmatic-restore
     cap_add:
       - SYS_ADMIN
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ services:
   borgmatic:
     image: ghcr.io/borgmatic-collective/borgmatic:1.8.11
     restart: always
-    container_name: borgmatic
     volumes:
       - ./data/borgmatic.d:/etc/borgmatic.d:ro              # borgmatic config file(s) + crontab.txt
       - ./data/.borgmatic:/root/.borgmatic                  # borgmatic state files
@@ -18,7 +17,6 @@ services:
   borgmatic-exporter:
     image: ghcr.io/maxim-mityutko/borgmatic-exporter:v0.2.3
     restart: always
-    container_name: borgmatic-exporter
     volumes:
       - ./data/borgmatic.d:/etc/borgmatic.d:ro
       - ./data/borgmatic-exporter/crontab.txt:/etc/borgmatic.d/crontab.txt:ro


### PR DESCRIPTION
We don't have the convention to explicitly set container names in docker-compose unless necessary. Removing them allows to run multiple app-borgmatic stacks next to each other without conflict.