### PR TITLE
Remove examples on SQL database backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,6 @@ borgmatic mount --archive latest --mount-point /mnt
 ```sh
 cp /mnt/data/backups/foo /restore
 ```
-   Database dumps made with the `postgresql_databases` or `mariadb_databases` hooks are in `/root/.borgmatic/postgresql_databases/localhost/`.
-   But Borgmatic has restore commands to deal with the database dumps easily.
 
 6. Unmount, exit and remove the restore container:
 ```sh

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -40,26 +40,3 @@ skip_actions:
 # keep_monthly: 6
 # keep_yearly: 1
 # keep_within: 5y
-
-# Borgmatic also provides special hooks for common databases. These have the advantage
-# that the dumps are streamed to the backup using a pipe, so they won't use space on
-# the host.
-# postgresql_databases:
-    # - name: all
-      # format: custom
-      # hostname: localhost
-      # port: 5432
-      # username: superuser for the database
-      # password: superuser's password
-      # pg_dump_command: docker exec <container> pg_dump
-      # pg_restore_command: docker exec <container> pg_restore
-      # psql_command: docker exec <container> psql
-# mariadb_databases:
-    # - name: all
-      # format: sql
-      # hostname: localhost
-      # port: 3306
-      # username: connection user for the database
-      # password: connection user's password
-      # mariadb_dump_command: docker exec <container> mariadb-dump
-      # mariadb_command: docker exec <container> mariadb


### PR DESCRIPTION
It's rather exceptional in the context of RPIO projects to use an SQL database. Removed backup config from examples to keep those as short and clear as possible. Users that still need them, can use the borg/borgmatic documentation to configure them.